### PR TITLE
Add ASCII Mandelbrot demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
 # Test
+
+This repository includes a sample Python script that displays an ASCII-art rendering
+of the Mandelbrot set.
+
+## How to run
+
+Use Python 3 to execute the script:
+
+```bash
+python mandelbrot_ascii.py
+```
+
+The program will print the Mandelbrot set to your terminal using simple
+characters.

--- a/mandelbrot_ascii.py
+++ b/mandelbrot_ascii.py
@@ -1,0 +1,32 @@
+import sys
+
+WIDTH = 80
+HEIGHT = 24
+MAX_ITER = 30
+
+# Determine region in complex plane
+RE_START, RE_END = -2.0, 1.0
+IM_START, IM_END = -1.0, 1.0
+
+for y in range(HEIGHT):
+    imag = IM_START + (y / HEIGHT) * (IM_END - IM_START)
+    for x in range(WIDTH):
+        real = RE_START + (x / WIDTH) * (RE_END - RE_START)
+        c = complex(real, imag)
+        z = 0j
+        iter = 0
+        while abs(z) <= 2 and iter < MAX_ITER:
+            z = z*z + c
+            iter += 1
+        # Choose character based on escape time
+        if iter == MAX_ITER:
+            char = '*'
+        elif iter > MAX_ITER / 2:
+            char = '+'
+        elif iter > MAX_ITER / 4:
+            char = '-'
+        else:
+            char = ' '
+        sys.stdout.write(char)
+    sys.stdout.write('\n')
+


### PR DESCRIPTION
## Summary
- add a simple Python script that prints an ASCII-art Mandelbrot set
- update README with instructions on running the new script

## Testing
- `python mandelbrot_ascii.py | head -n 3`


------
https://chatgpt.com/codex/tasks/task_e_688732458e108328994e381cbda4c864